### PR TITLE
refactor: emoji picker to use GroupedVirtuoso

### DIFF
--- a/src/components/design/media/picker/Picker.stories.tsx
+++ b/src/components/design/media/picker/Picker.stories.tsx
@@ -68,6 +68,11 @@ const Template: ComponentStory<typeof Picker> = (args) => (
                                         .value as Server
                                 ).generateIconURL(),
                             },
+                            {
+                                id: "default",
+                                name: "Default",
+                                emoji: "smiley",
+                            },
                         ]}
                     />
                 </div>

--- a/src/components/design/media/picker/Picker.tsx
+++ b/src/components/design/media/picker/Picker.tsx
@@ -143,7 +143,7 @@ type Generated = {
     /**
      * Emoji items
      */
-    items: string[][][];
+    items: string[][];
 
     /**
      * Emoji count for each category
@@ -175,8 +175,9 @@ export function Picker({ emojis, categories, renderEmoji: Emoji }: Props) {
             const q = query.trim();
 
             // Prepare data structures
-            const items: string[][][] = [];
+            const items: string[][] = [];
             const categoriesWithDefault: Category[] = [];
+            const categoryCounts: number[] = [];
 
             // Iterate through all categories
             for (const cat of [
@@ -211,16 +212,14 @@ export function Picker({ emojis, categories, renderEmoji: Emoji }: Props) {
                 const categoryEmojis = sliceArray(append, ROW_SIZE);
 
                 // Append emojis to full list
-                items.push(categoryEmojis);
+                items.push(...categoryEmojis);
 
                 // Append non empty category
                 categoriesWithDefault.push(cat);
-            }
 
-            // Calculate total number of rows for each category
-            const categoryCounts = items
-                .map((category) => category.length)
-                .filter((count) => count !== 0);
+                // Append category length
+                categoryCounts.push(categoryEmojis.length)
+            }
 
             return {
                 items,
@@ -282,25 +281,13 @@ export function Picker({ emojis, categories, renderEmoji: Emoji }: Props) {
                     }}
                     itemContent={(itemIndex, groupIndex) => {
                         console.log("Item:", itemIndex, "Group:", groupIndex);
-                        const itemsBeforeCount = categoryCounts
-                            .slice(0, groupIndex)
-                            .reduce(
-                                (sumSoFar, categoryCount) =>
-                                    sumSoFar + categoryCount,
-                                0,
-                            );
-
-                        const offsetIndex = itemIndex - itemsBeforeCount;
-                        console.log(offsetIndex);
                         return (
                             <>
-                                {items[groupIndex][offsetIndex].map(
-                                    (emojiString) => (
-                                        <EmojiContainer>
-                                            <Emoji emoji={emojiString} />
-                                        </EmojiContainer>
-                                    ),
-                                )}
+                                {items[itemIndex].map((emojiString) => (
+                                    <EmojiContainer>
+                                        <Emoji emoji={emojiString} />
+                                    </EmojiContainer>
+                                ))}
                             </>
                         );
                     }}

--- a/src/components/design/media/picker/Picker.tsx
+++ b/src/components/design/media/picker/Picker.tsx
@@ -218,7 +218,7 @@ export function Picker({ emojis, categories, renderEmoji: Emoji }: Props) {
                 categoriesWithDefault.push(cat);
 
                 // Append category length
-                categoryCounts.push(categoryEmojis.length)
+                categoryCounts.push(categoryEmojis.length);
             }
 
             return {
@@ -251,13 +251,13 @@ export function Picker({ emojis, categories, renderEmoji: Emoji }: Props) {
                     groupContent={(groupIndex) => {
                         return (
                             <CategoryBar>
-                                {categoriesWithDefault[groupIndex].id ===
-                                "default" ? (
-                                    <EmojiContainer>
-                                        <Emoji emoji="smiley" />
-                                    </EmojiContainer>
-                                ) : (
-                                    <CategoryIcon>
+                                <CategoryIcon>
+                                    {categoriesWithDefault[groupIndex].id ===
+                                    "default" ? (
+                                        <EmojiContainer>
+                                            <Emoji emoji="smiley" />
+                                        </EmojiContainer>
+                                    ) : (
                                         <Avatar
                                             size={32}
                                             fallback={
@@ -271,8 +271,8 @@ export function Picker({ emojis, categories, renderEmoji: Emoji }: Props) {
                                                 ].iconURL
                                             }
                                         />
-                                    </CategoryIcon>
-                                )}
+                                    )}
+                                </CategoryIcon>
                                 <CategoryName>
                                     {categoriesWithDefault[groupIndex].name}
                                 </CategoryName>


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects

Tried refactoring the `Picker` component to use GroupedVirtuoso([API Reference](https://virtuoso.dev/virtuoso-api-reference/#groupedvirtuoso-properties), [Example](https://virtuoso.dev/grouped-numbers/)) and came with the following implementation.

Some things to note:
* `categoriesWithDefault` should probably be changed to `activeCategories`, and I think the default category should be supplied in the `MessageBox` component.
* The implemented solution to display emojis as a grid is to slice each category's emoji collection into chunks of maximum length of 8 (current `ROW_SIZE`)(lines 200-212) and render each row as an item (lines 284-292), this is roughly based on [#194 (comment)](https://github.com/petyosi/react-virtuoso/issues/194#issuecomment-953030122) 
* ~~`offsetIndex` calculates the number of rows before current row, so that the first item in row is index 0~~ (not needed after [`dd56dad` (#4)](https://github.com/revoltchat/components/pull/4/commits/dd56dad321586a4a92ef131facd4f2624e568a83) which uses a 2D `items` array with all `categoryEmojis` arrays spread)
* GroupedVirtuoso will allow easier implementation for category navigation, using [Scroll to Group](https://virtuoso.dev/scroll-to-group/)

Preview:
![previewing emoji picker](https://user-images.githubusercontent.com/38331868/178124549-5594a51c-1428-4abe-a371-dce94f981674.png)
