### PR TITLE
Add overflow hidden to the role list under server settings.

### DIFF
--- a/src/components/pages/settings/permissions/RoleList.tsx
+++ b/src/components/pages/settings/permissions/RoleList.tsx
@@ -85,8 +85,9 @@ export const RoleList = observer(
                         <ButtonItem
                             key={role.id}
                             selected={role.id === selected}
-                            style={{ color: role.colour! }}
-                            onClick={() => onSelect?.(role.id)}>
+                            style={{ overflow: 'hidden', color: role.colour! }}
+                            onClick={() => onSelect?.(role.id)}
+                            title={role.name}>
                             <Rank>{role_rank}</Rank>
                             {role.name}
                             {typeof rank === "number" && role_rank <= rank && (


### PR DESCRIPTION
Makes it so that the text within the role list button doesn't overflow ontop of the permission side. I also added a title so that when the button is hovered it displays the whole role text. 

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended

From this:
<img width="763" height="427" alt="image" src="https://github.com/user-attachments/assets/6d1e888b-96c8-4836-8b38-6ae60e54cd8f" />

To this:
<img width="797" height="396" alt="image" src="https://github.com/user-attachments/assets/1e75c93e-0ec6-4a90-a3c2-db2bfed0de6a" />

